### PR TITLE
fix: restore overriding provider value through copy prop

### DIFF
--- a/example/Example.tsx
+++ b/example/Example.tsx
@@ -1,11 +1,19 @@
-import React from 'react';
-import { CopyfulProvider, Copyful } from './configureCopy';
+import React, { useState } from 'react';
+import { CopyfulProvider, Copyful, getCopySomehow, Locales } from './configureCopy';
+import { copy } from './copy';
 import { HeaderSection } from './HeaderSection';
 
 export const Example = () => {
+  const [locale, setLocale] = useState<Locales>('en-us');
+
+  const toggleLocale = () => {
+    setLocale(locale === 'en-us' ? '1337' : 'en-us');
+  };
+
   return (
-    <CopyfulProvider>
+    <CopyfulProvider copy={getCopySomehow(copy, locale)}>
       {/* Example using Hooks */}
+      <button onClick={toggleLocale}>Toggle Locale</button>
       <HeaderSection />
 
       {/* Example using a render prop */}

--- a/example/copy.ts
+++ b/example/copy.ts
@@ -19,6 +19,5 @@ export const copy = {
     },
     body:
       "pr0duc7 c0py c4n b3c0m3 d1ff1cul7 70 m4n463 4cr055 pr0duc7 pl47f0rm5 45 w3ll 45 1n73rn4l d3516n 4nd 3n61n33r1n6 700l1n6. c0py ch4n635 fr3qu3n7ly 4nd f0r m4ny r3450n5 (m0r3 cl4r17y, 7yp0, l364l 6u1d4nc3, 37c...) 4nd 3n61n33r1n6 **mu57** b3 1nv0lv3d 70 m4k3 7h353 ch4n635. 50m371m35 7h3 ch4n635 4r3n'7 57r416h7f0rw4rd - 17 b3c0m35 4 hun7 4cr055 r3p05170r135 0r c0py h45 dr1f73d 4cr055 0ur w3b 4nd n471v3 4ppl1c4710n5.",
-    footer: '4w350m3? - {anotherValue}',
   },
-} as const;
+};

--- a/src/copyful.tsx
+++ b/src/copyful.tsx
@@ -1,18 +1,22 @@
-import React, { ReactElement } from 'react';
+import React, { useState, useEffect, ReactElement } from 'react';
 import { getInterpolatedCopy } from './helpers';
 
 type InterpolationContext = Record<string, string | number>;
 
 export const createCopyful = <TCopy extends object>(defaultCopy: TCopy) => {
-  const Context = React.createContext(defaultCopy);
+  const Context = React.createContext<Partial<TCopy>>(defaultCopy);
 
-  const CopyfulProvider: React.FC = ({ children }) => (
-    <Context.Provider value={defaultCopy}>{children}</Context.Provider>
-  );
+  const CopyfulProvider: React.FC<{ copy?: Partial<TCopy> }> = ({ children, copy }) => {
+    const [currentCopy, setCurrentCopy] = useState<Partial<TCopy>>(defaultCopy);
+    useEffect(() => {
+      setCurrentCopy(copy || defaultCopy);
+    }, [copy]);
+    return <Context.Provider value={currentCopy}>{children}</Context.Provider>;
+  };
 
   const useCopy = <T extends keyof TCopy>(key: T, context: InterpolationContext = {}) => {
     const copy = React.useContext(Context);
-    const copyBlock = copy[key];
+    const copyBlock = copy[key] || defaultCopy[key];
 
     const interpolatedCopy: TCopy[T] = context
       ? getInterpolatedCopy(copyBlock, context)

--- a/src/copyful.tsx
+++ b/src/copyful.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, ReactElement } from 'react';
+import React, { ReactElement } from 'react';
 import { getInterpolatedCopy } from './helpers';
 
 type InterpolationContext = Record<string, string | number>;
@@ -6,13 +6,9 @@ type InterpolationContext = Record<string, string | number>;
 export const createCopyful = <TCopy extends object>(defaultCopy: TCopy) => {
   const Context = React.createContext<Partial<TCopy>>(defaultCopy);
 
-  const CopyfulProvider: React.FC<{ copy?: Partial<TCopy> }> = ({ children, copy }) => {
-    const [currentCopy, setCurrentCopy] = useState<Partial<TCopy>>(defaultCopy);
-    useEffect(() => {
-      setCurrentCopy(copy || defaultCopy);
-    }, [copy]);
-    return <Context.Provider value={currentCopy}>{children}</Context.Provider>;
-  };
+  const CopyfulProvider: React.FC<{ copy?: Partial<TCopy> }> = ({ children, copy }) => (
+    <Context.Provider value={copy || defaultCopy}>{children}</Context.Provider>
+  );
 
   const useCopy = <T extends keyof TCopy>(key: T, context: InterpolationContext = {}) => {
     const copy = React.useContext(Context);


### PR DESCRIPTION
This should enable overriding `defaultCopy` from `createCopyful(defaultCopy)` through the value prop in `CopyfulProvider`. It also adds defaulting to the `defaultCopy` if there are ever missing keys in the new copy passed in via provider prop. 

`as const` can be restored for non localization use cases for added safety in ensuring the right copy strings are used.